### PR TITLE
Fix nosql.one that was not returning the record

### DIFF
--- a/index.js
+++ b/index.js
@@ -399,8 +399,8 @@ Database.prototype.all = function(fnMap, fnCallback, itemSkip, itemTake) {
 */
 Database.prototype.one = function(fnMap, fnCallback) {
 
-    var cb = function(selected) {
-        fnCallback(null, selected ? selected[0] || null : null);
+    var cb = function(err, selected) {
+        fnCallback(err, selected ? selected[0] || null : null);
     };
 
     return this.read(fnMap, cb, 0, 1, false, 'one');


### PR DESCRIPTION
because `nosql.read` return two arguments and the `nosql.one` callback expects only one